### PR TITLE
Don't ignore requested width and height.

### DIFF
--- a/src/org/axgl/Ax.as
+++ b/src/org/axgl/Ax.as
@@ -429,8 +429,8 @@ package org.axgl {
 		private function initialize():void {
 			stage.frameRate = requestedFramerate;
 			
-			Ax.width = width == 0 ? stage.stageWidth : width;
-			Ax.height = height == 0 ? stage.stageHeight : height;
+			Ax.width = requestedWidth == 0 ? stage.stageWidth : requestedWidth;
+			Ax.height = requestedHeight == 0 ? stage.stageHeight : requestedHeight;
 			
 			context.configureBackBuffer(Ax.width, Ax.height, 0, false);
 			context.enableErrorChecking = false;


### PR DESCRIPTION
Right now, Axgl completely ignores the requested width and height. "width" and "height" should always be 0 in this function, so I think my change repairs it to what was actually supposed to happen.
