### PR TITLE
Don't draw if scale is set to zero.

### DIFF
--- a/src/org/axgl/AxSprite.as
+++ b/src/org/axgl/AxSprite.as
@@ -368,7 +368,7 @@ package org.axgl {
 				dirty = false;
 			}
 
-			if (screen.x > Ax.width || screen.y > Ax.height || screen.x + frameWidth < 0 || screen.y + frameHeight < 0) {
+			if (screen.x > Ax.width || screen.y > Ax.height || screen.x + frameWidth < 0 || screen.y + frameHeight < 0 || scale.x == 0 || scale.y == 0) {
 				return;
 			}
 			


### PR DESCRIPTION
This makes it possible to make something disappear by scaling it to zero. Useful if you use a pattern like here: http://flashgamedojo.com/wiki/index.php?title=UI,_HUD_or_Status_Overlay_(Flixel)
