### PR TITLE
Add #clear() for AxGroup

### DIFF
--- a/src/org/axgl/AxGroup.as
+++ b/src/org/axgl/AxGroup.as
@@ -67,6 +67,16 @@ package org.axgl {
 		}
 
 		/**
+		 * Removes all entities from the group.
+		 *
+		 * @return This group.
+		 */
+		public function clear():AxGroup {
+      members.length = 0;
+			return this;
+		}
+
+		/**
 		 * @inheritDoc
 		 */
 		override public function update():void {


### PR DESCRIPTION
This is an easy way to completely empty a given group. A user could do this herself, but I think this should be in the API.
